### PR TITLE
Refactor code to follow rust idioms better

### DIFF
--- a/src/crypto/pgp.rs
+++ b/src/crypto/pgp.rs
@@ -129,14 +129,14 @@ impl crypto::Verifying<crypto::algorithm::RSA> for Verifier {
             self.public_key
                 .public_subkeys
                 .iter()
-                .filter_map(|sub_key| {
-                    if sub_key.key_id().as_ref() == key_id.as_ref() {
+                .filter(|sub_key| {
+                    let matching_key = sub_key.key_id().as_ref() == key_id.as_ref();
+                    if matching_key {
                         log::trace!("Found a matching key id {:?} == {:?}", sub_key.key_id(), key_id);
-                        Some(sub_key)
                     } else {
                         log::trace!("Not the one we want: {:?}", sub_key);
-                        None
                     }
+                    matching_key
                 })
                 .fold(
                     Err(RPMError::from(format!("No key id matched the signature issuer key id: {:?}", key_id))),

--- a/src/crypto/pgp.rs
+++ b/src/crypto/pgp.rs
@@ -187,10 +187,10 @@ impl Verifier {
 #[cfg(test)]
 mod test {
 
+    use super::super::{echo_signature, Signing, Verifying};
     use super::*;
-    use super::super::{Signing, Verifying, echo_signature};
 
-    use crate::signature::crypto::test::{load_asc_keys};
+    use crate::signature::crypto::test::load_asc_keys;
 
     use super::Signer;
     use super::Verifier;

--- a/src/crypto/traits.rs
+++ b/src/crypto/traits.rs
@@ -3,7 +3,6 @@
 //! Does not contain hashing! Hashes are fixed by the rpm
 //! "spec" to sha1, md5 (yes, that is correct), sha2_256.
 
-#[allow(unused)]
 use crate::errors::*;
 use std::fmt::Debug;
 

--- a/src/crypto/traits.rs
+++ b/src/crypto/traits.rs
@@ -32,9 +32,9 @@ where
     fn sign(&self, data: &[u8]) -> Result<Self::Signature, RPMError>;
 }
 
-impl<A,T,S> Signing<A> for &T
+impl<A, T, S> Signing<A> for &T
 where
-    T: Signing<A,Signature=S>,
+    T: Signing<A, Signature = S>,
     A: algorithm::Algorithm,
     S: AsRef<[u8]>,
 {
@@ -54,11 +54,9 @@ where
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), RPMError>;
 }
 
-
-
-impl<A,T,S> Verifying<A> for &T
+impl<A, T, S> Verifying<A> for &T
 where
-    T: Verifying<A,Signature=S>,
+    T: Verifying<A, Signature = S>,
     A: algorithm::Algorithm,
     S: AsRef<[u8]>,
 {
@@ -67,7 +65,6 @@ where
         T::verify(self, data, signature)
     }
 }
-
 
 pub mod key {
 

--- a/src/tests_validate.rs
+++ b/src/tests_validate.rs
@@ -141,8 +141,7 @@ mod pgp {
 
         // verify
         {
-            let out_file =
-                std::fs::File::open(&out_file).expect("should be able to open rpm file");
+            let out_file = std::fs::File::open(&out_file).expect("should be able to open rpm file");
             let mut buf_reader = std::io::BufReader::new(out_file);
             let package = RPMPackage::parse(&mut buf_reader)?;
 
@@ -188,8 +187,7 @@ rpm  -vv --checksig /out/{rpm_file} 2>&1
         let mut buf_reader = std::io::BufReader::new(out_file);
         let package = RPMPackage::parse(&mut buf_reader)?;
 
-        package
-            .verify_signature(verifier)?;
+        package.verify_signature(verifier)?;
 
         Ok(())
     }
@@ -244,9 +242,7 @@ gpg --verify /out/test.file.sig /out/test.file 2>&1
 
         Ok(())
     }
-
 }
-
 
 fn wait_and_print_helper(mut child: std::process::Child, stdin_cmd: &str) -> std::io::Result<()> {
     if let Some(ref mut stdin) = child.stdin {


### PR DESCRIPTION
Fixed some things suggested by ```cargo clippy```

Moved some tests around to follow the standard test organization
https://doc.rust-lang.org/book/ch11-03-test-organization.html

Added a lib.rs file