### PR TITLE
sequential read of chunks - reduce memory footprint for sign/verify/hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub use crate::errors::*;
 pub(crate) mod constants;
 pub use crate::constants::*;
 
+mod sequential_cursor;
+
 mod rpm;
 pub use crate::rpm::*;
 

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -24,6 +24,10 @@ pub struct Signer {
 
 impl traits::Signing<traits::algorithm::RSA> for Signer {
     type Signature = Vec<u8>;
+
+    /// Despite the fact the API suggest zero copy pattern,
+    /// it internally creates a copy until crate `pgp` provides
+    /// a `Read` based implementation.
     fn sign<R: Read>(&self, mut data: R) -> Result<Self::Signature, RPMError> {
         let passwd_fn = || String::new();
 
@@ -111,6 +115,9 @@ impl Verifier {
 
 impl traits::Verifying<traits::algorithm::RSA> for Verifier {
     type Signature = Vec<u8>;
+    /// Despite the fact the API suggest zero copy pattern,
+    /// it internally creates a copy until crate `pgp` provides
+    /// a `Read` based implementation.
     fn verify<R: Read>(&self, mut data: R, signature: &[u8]) -> Result<(), RPMError> {
         let signature = Self::parse_signature(signature)?;
 

--- a/src/rpm/signature/traits.rs
+++ b/src/rpm/signature/traits.rs
@@ -6,6 +6,7 @@
 #[allow(unused)]
 use crate::errors::*;
 use std::fmt::Debug;
+use std::io::Read;
 
 pub mod algorithm {
 
@@ -29,7 +30,7 @@ where
     Self::Signature: AsRef<[u8]>,
 {
     type Signature;
-    fn sign(&self, data: &[u8]) -> Result<Self::Signature, RPMError>;
+    fn sign<R: Read>(&self, data: R) -> Result<Self::Signature, RPMError>;
 }
 
 impl<A, T, S> Signing<A> for &T
@@ -39,8 +40,8 @@ where
     S: AsRef<[u8]>,
 {
     type Signature = S;
-    fn sign(&self, data: &[u8]) -> Result<Self::Signature, RPMError> {
-        T::sign(self, data)
+    fn sign<R: Read>(&self, data: R) -> Result<Self::Signature, RPMError> {
+        T::sign::<R>(self, data)
     }
 }
 
@@ -51,7 +52,7 @@ where
     Self::Signature: AsRef<[u8]>,
 {
     type Signature;
-    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), RPMError>;
+    fn verify<R: Read>(&self, data: R, signature: &[u8]) -> Result<(), RPMError>;
 }
 
 impl<A, T, S> Verifying<A> for &T
@@ -61,8 +62,8 @@ where
     S: AsRef<[u8]>,
 {
     type Signature = S;
-    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), RPMError> {
-        T::verify(self, data, signature)
+    fn verify<R: Read>(&self, data: R, signature: &[u8]) -> Result<(), RPMError> {
+        T::verify::<R>(self, data, signature)
     }
 }
 
@@ -90,7 +91,7 @@ where
     A: algorithm::Algorithm,
 {
     type Signature = Vec<u8>;
-    fn sign(&self, _data: &[u8]) -> Result<Self::Signature, RPMError> {
+    fn sign<R: Read>(&self, _data: R) -> Result<Self::Signature, RPMError> {
         unreachable!("if you want to verify, you need to implement `sign` of the `Signing` trait")
     }
 }
@@ -101,7 +102,7 @@ where
     A: algorithm::Algorithm,
 {
     type Signature = Vec<u8>;
-    fn verify(&self, _data: &[u8], _x: &[u8]) -> Result<(), RPMError> {
+    fn verify<R: Read>(&self, _data: R, _x: &[u8]) -> Result<(), RPMError> {
         unreachable!(
             "if you want to verify, you need to implement `verify` of the `Verifying` trait"
         )

--- a/src/sequential_cursor.rs
+++ b/src/sequential_cursor.rs
@@ -1,0 +1,108 @@
+//! Cursor implementation over multiple slices
+pub(crate) struct SeqCursor<'s> {
+    cursors: Vec<std::io::Cursor<&'s [u8]>>,
+    position: u64,
+    len: usize,
+}
+
+impl<'s> SeqCursor<'s> {
+    /// Add an additional slice to the end of the cursor
+    ///
+    /// Does not modify the current cursors position.
+    pub(crate) fn add<'b>(&mut self, another: &'b [u8])
+    where
+        'b: 's,
+    {
+        let cursor = std::io::Cursor::<&'s [u8]>::new(another);
+        self.cursors.push(cursor);
+        self.len += another.len();
+    }
+
+    /// Crate a new cursor based on a slice of bytes slices.
+    pub(crate) fn new<'b>(slices: &[&'b [u8]]) -> Self
+    where
+        'b: 's,
+    {
+        let len = slices.iter().fold(0usize, |acc, slice| slice.len() + acc);
+        Self {
+            cursors: slices
+                .into_iter()
+                .map(|slice| std::io::Cursor::new(*slice))
+                .collect::<Vec<_>>(),
+            position: 0u64,
+            len,
+        }
+    }
+
+    /// Total length of all slices summed up.
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<'s> std::io::Read for SeqCursor<'s> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut total_read = 0usize;
+        let mut acc_offset = 0usize;
+        for cursor in self.cursors.iter_mut() {
+            let chunk_len = cursor.get_ref().len();
+            acc_offset += chunk_len;
+            if self.position < acc_offset as u64 {
+                let remaining_in_chunk = (acc_offset as u64 - self.position) as usize;
+                let fin = std::cmp::min(total_read + remaining_in_chunk, buf.len());
+                let read = cursor.read(&mut buf[total_read..fin])?;
+                total_read += read;
+                if total_read == buf.len() {
+                    break;
+                }
+            }
+        }
+        self.position += total_read as u64;
+        Ok(total_read)
+    }
+}
+
+impl<'s> std::io::Seek for SeqCursor<'s> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.position = match pos {
+            std::io::SeekFrom::Start(rel) => rel,
+            std::io::SeekFrom::End(rel) => {
+                let total = self
+                    .cursors
+                    .iter()
+                    .fold(0u64, |acc, cursor| acc + cursor.get_ref().len() as u64);
+                (total as i64 - rel) as u64
+            }
+            std::io::SeekFrom::Current(rel) => (self.position as i64 + rel) as u64,
+        };
+        Ok(self.position)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Read;
+    use std::io::Seek;
+
+    #[test]
+    fn sequential_cursor() {
+        let c1 = vec![1u8; 17];
+        let c2 = vec![2u8; 17];
+        let c3 = vec![3u8; 17];
+
+        let mut buf = Vec::<u8>::with_capacity(17 * 3);
+        unsafe {
+            buf.set_len(17 * 3);
+        }
+        let mut sq = SeqCursor::new(&[c1.as_slice(), c2.as_slice(), c3.as_slice()]);
+
+        sq.seek(std::io::SeekFrom::Current(16)).unwrap();
+        sq.read(&mut buf[0..4]).unwrap();
+        assert_eq!(buf[0..4].to_vec(), vec![1u8, 2u8, 2u8, 2u8]);
+
+        sq.seek(std::io::SeekFrom::Current(12)).unwrap();
+        sq.read(&mut buf[4..8]).unwrap();
+        assert_eq!(buf[4..8].to_vec(), vec![2u8, 2u8, 3u8, 3u8]);
+    }
+}


### PR DESCRIPTION
~Contains changes of #12 , so should be merged after that.~

Currently this does not yield much gains, except for avoiding one giant allocation for hashing with md5 - `rpgp` currently does not support `Read` based signing https://github.com/rpgp/rpgp/issues/99 .
One could work around this by impl chunk wise hashing by using the lower level API of `pgp` and calling the hasher explicitly, this is not implemented just yet.

Ref #11 