### PR TITLE
feat: Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["parsing", "development-tools"]
 name = "rpm"
 
 [dependencies]
+thiserror = "1"
 nom = "5.1"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -28,7 +28,7 @@ impl std::str::FromStr for Compressor {
         match raw {
             "none" => Ok(Compressor::None(Vec::new())),
             "gzip" => Ok(Compressor::Gzip(libflate::gzip::Encoder::new(Vec::new())?)),
-            _ => Err(RPMError::new(&format!("unknown compressor type {}", raw))),
+            _ => Err(RPMError::UnknownCompressorType(raw.to_string())),
         }
     }
 }

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -106,42 +106,26 @@ impl RPMPackage {
         let signature_header_only = self
             .metadata
             .signature
-            .get_entry_binary_data(IndexSignatureTag::RPMSIGTAG_RSA)
-            .map_err(|e| format!("Missing header-only signature / RPMSIGTAG_RSA: {:?}", e))?;
+            .get_entry_binary_data(IndexSignatureTag::RPMSIGTAG_RSA)?;
 
         crate::signature::echo_signature("signature_header(header only)", signature_header_only);
 
         let signature_header_and_content = self
             .metadata
             .signature
-            .get_entry_binary_data(IndexSignatureTag::RPMSIGTAG_PGP)
-            .map_err(|e| format!("Missing header+content signature / RPMSIGTAG_PGP: {:?}", e))?;
+            .get_entry_binary_data(IndexSignatureTag::RPMSIGTAG_PGP)?;
 
         crate::signature::echo_signature(
             "signature_header(header and content)",
             signature_header_and_content,
         );
 
-        verifier
-            .verify(header_bytes.as_slice(), signature_header_only)
-            .map_err(|e| {
-                format!(
-                    "Failed to verify header-only signature / RPMSIGTAG_RSA: {:?}",
-                    e
-                )
-            })?;
+        verifier.verify(header_bytes.as_slice(), signature_header_only)?;
 
         let header_and_content_cursor =
             SeqCursor::new(&[header_bytes.as_slice(), self.content.as_slice()]);
 
-        verifier
-            .verify(header_and_content_cursor, signature_header_and_content)
-            .map_err(|e| {
-                format!(
-                    "Failed to verify header+content signature / RPMSIGTAG_PGP: {:?}",
-                    e
-                )
-            })?;
+        verifier.verify(header_and_content_cursor, signature_header_and_content)?;
 
         Ok(())
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -259,10 +259,11 @@ fn test_rpm_header() -> Result<(), Box<dyn std::error::Error>> {
 fn test_region_tag() -> Result<(), Box<dyn std::error::Error>> {
     let region_entry = Header::create_region_tag(IndexSignatureTag::HEADER_SIGNATURES, 2, 400);
 
-    let data = match region_entry.data {
-        IndexData::Bin(d) => d,
-        _ => return Err(Box::new(RPMError::new("should be bin"))),
-    };
+    let possible_binary = region_entry.data.as_binary();
+
+    assert!(possible_binary.is_some(), "should be binary");
+
+    let data = possible_binary.unwrap();
 
     let (_, entry) = IndexEntry::<IndexSignatureTag>::parse(&data)?;
 


### PR DESCRIPTION
The error type is now an enum with variants for different error scenarios.
To reduce boilerplate code the _thiserror_ crate was used.
Errors intended for signature handling are more generic because it is
likely that library users will implement a custom signer at some point
in time.

Fixes #14 