### PR TITLE
feat/pgp: remove workaround for missing trait `io::Read` in crate `pgp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.9"
 md-5 = "0.9"
 sha1 = "0.6"
 rand = { version = "0.7" }
-pgp = { version = "0.6", optional = true }
+pgp = { version = "0.7", optional = true }
 chrono = "0.4"
 log = "0.4"
 

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -30,7 +30,7 @@ impl traits::Signing<traits::algorithm::RSA> for Signer {
     /// Despite the fact the API suggest zero copy pattern,
     /// it internally creates a copy until crate `pgp` provides
     /// a `Read` based implementation.
-    fn sign<R: Read>(&self, mut data: R) -> Result<Self::Signature, RPMError> {
+    fn sign<R: Read>(&self, data: R) -> Result<Self::Signature, RPMError> {
         let passwd_fn = || String::new();
 
         let now = now();
@@ -49,13 +49,9 @@ impl traits::Signing<traits::algorithm::RSA> for Signer {
                 //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition
             ],
         };
-        // currently the copy is necessary due to a lack of API allowing
-        // something `std::io::Read` based: https://github.com/rpgp/rpgp/issues/99
-        let mut buf = Vec::with_capacity(16384);
-        let _ = data.read_to_end(&mut buf)?;
 
         let signature_packet = sig_cfg
-            .sign(&self.secret_key, passwd_fn, buf.as_slice())
+            .sign(&self.secret_key, passwd_fn, data)
             .map_err(|e| RPMError::SignError(Box::new(e)))?;
 
         let mut signature_bytes = Vec::with_capacity(1024);
@@ -123,17 +119,11 @@ impl traits::Verifying<traits::algorithm::RSA> for Verifier {
 
         log::debug!("Signature issued by: {:?}", signature.issuer());
 
-        // currently the copy is necessary due to a lack of API allowing
-        // something `std::io::Read` based: https://github.com/rpgp/rpgp/issues/99
-        let mut buf = Vec::with_capacity(16384);
-        let _ = data.read_to_end(&mut buf)?;
-        let buf = &buf[..];
-
         if let Some(key_id) = signature.issuer() {
             log::trace!("Signature has issuer ref: {:?}", key_id);
 
             if self.public_key.key_id() == *key_id {
-                return signature.verify(&self.public_key, buf).map_err(|e| {
+                return signature.verify(&self.public_key, data).map_err(|e| {
                     RPMError::VerificationError {
                         source: Box::new(e),
                         key_ref: format!("{:?}", key_id),
@@ -170,7 +160,7 @@ impl traits::Verifying<traits::algorithm::RSA> for Verifier {
                     |previous_res, sub_key| {
                         if previous_res.is_err() {
                             log::trace!("Test next candidate subkey");
-                            signature.verify(sub_key, buf).map_err(|e| {
+                            signature.verify(sub_key, &mut data).map_err(|e| {
                                 RPMError::VerificationError {
                                     source: Box::new(e),
                                     key_ref: format!("{:?}", sub_key.key_id()),
@@ -188,7 +178,7 @@ impl traits::Verifying<traits::algorithm::RSA> for Verifier {
                 self.public_key.primary_key.key_id()
             );
             signature
-                .verify(&self.public_key, buf)
+                .verify(&self.public_key, data)
                 .map_err(|e| RPMError::VerificationError {
                     source: Box::new(e),
                     key_ref: format!("{:?}", self.public_key.key_id()),


### PR DESCRIPTION
`rpgp v0.7.0` contains the necessary change for this to land without cargo overwrites.