### PR TITLE
Implement Debug for RPMPackage

### DIFF
--- a/src/rpm/headers/lead.rs
+++ b/src/rpm/headers/lead.rs
@@ -25,6 +25,23 @@ pub struct Lead {
     reserved: [u8; 16],
 }
 
+impl std::fmt::Debug for Lead {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = String::from_utf8_lossy(&self.name);
+        f.debug_struct("Lead")
+            .field("magic", &self.magic)
+            .field("major", &self.major)
+            .field("minor", &self.minor)
+            .field("package_type", &self.package_type)
+            .field("arch", &self.arch)
+            .field("name", &name)
+            .field("os", &self.os)
+            .field("signature_type", &self.signature_type)
+            .field("reserved", &self.reserved)
+            .finish()
+    }
+}
+
 impl Lead {
     pub(crate) fn parse(input: &[u8]) -> Result<Self, RPMError> {
         let (rest, magic) = complete::take(4usize)(input)?;

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -15,6 +15,7 @@ use std::io::{Read, Seek, SeekFrom};
 ///
 /// Can either be created using the [`RPMPackageBuilder`](super::builder::RPMPackageBuilder)
 /// or used with [`parse`](`self::RPMPackage::parse`) to obtain from a file.
+#[derive(Debug)]
 pub struct RPMPackage {
     /// Header and metadata structures.
     ///
@@ -131,7 +132,7 @@ impl RPMPackage {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub struct RPMPackageMetadata {
     pub lead: Lead,
     pub signature: Header<IndexSignatureTag>,


### PR DESCRIPTION
This has a manual implementation of Debug for Lead, and then derives it
for the rest if the structs.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>