### PR TITLE
Read release into a String, do not require it to be u16 first

### DIFF
--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -219,8 +219,8 @@ impl RPMBuilder {
         self
     }
 
-    pub fn release(mut self, release: u16) -> Self {
-        self.release = format!("{}", release);
+    pub fn release<T: ToString>(mut self, release: T) -> Self {
+        self.release = release.to_string();
         self
     }
 


### PR DESCRIPTION
    Many RPM based Linux distributions use release tags like '1.fc33'
    instead of just '1'. The current implementation, with release being read
    as a u16 seems to make using release tags like '1.fc33' impossible.
    
    This change makes release() into a generic function, that accepts types
    that implement the ToString trait, hence as I understand it (I'm quite
    new to rust), both String and various numerical types like u16 should be
    accepted, changing as little as possible of the existing API.
    
    I'm primarily pushing this change because I want to be able to use
    '1.fc33' style release tags with the generate-rpm crate, which is based
    on rpm-rs.
