### PR TITLE
feat: allow more options for release tags

### DIFF
--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -219,8 +219,8 @@ impl RPMBuilder {
         self
     }
 
-    pub fn release(mut self, release: u16) -> Self {
-        self.release = format!("{}", release);
+    pub fn release<T: Into<String>>(mut self, release: T) -> Self {
+        self.release = release.into();
         self
     }
 


### PR DESCRIPTION
Unfortunately, not everyone uses purely numeric release tags -- Some add dist tags.

Thank you for the fantastic crate! Please let me know if you'd like any changes.