### PR TITLE
Introduce support for zstd compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.9"
 md-5 = "0.9"
 sha1 = "0.6"
 rand = { version = "0.7" }
-pgp = { git="https://github.com/rpgp/rpgp.git", optional = true }
+pgp = { version="0.7.2", optional = true }
 chrono = "0.4"
 log = "0.4"
 zstd = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.9"
 md-5 = "0.9"
 sha1 = "0.6"
 rand = { version = "0.7" }
-pgp = { version = "0.7", optional = true }
+pgp = { git="https://github.com/rpgp/rpgp.git", commit="26affacc8ad14ce7799a7b5625a98543a3098f25", optional = true }
 chrono = "0.4"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ sha2 = "0.9"
 md-5 = "0.9"
 sha1 = "0.6"
 rand = { version = "0.7" }
-pgp = { git="https://github.com/rpgp/rpgp.git", commit="26affacc8ad14ce7799a7b5625a98543a3098f25", optional = true }
+pgp = { git="https://github.com/rpgp/rpgp.git", optional = true }
 chrono = "0.4"
 log = "0.4"
+zstd = "0.9.0"
 
 [dev-dependencies]
 rsa = { version = "^0.3.0" }

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -1,10 +1,10 @@
-use std::io::Write;
-
 use crate::errors::*;
+use std::io::Write;
 
 pub enum Compressor {
     None(Vec<u8>),
     Gzip(libflate::gzip::Encoder<Vec<u8>>),
+    Zstd(zstd::stream::Encoder<'static, Vec<u8>>),
 }
 
 impl Write for Compressor {
@@ -12,22 +12,28 @@ impl Write for Compressor {
         match self {
             Compressor::None(data) => data.write(content),
             Compressor::Gzip(encoder) => encoder.write(content),
+            Compressor::Zstd(encoder) => encoder.write(content),
         }
     }
     fn flush(&mut self) -> Result<(), std::io::Error> {
         match self {
             Compressor::None(data) => data.flush(),
             Compressor::Gzip(encoder) => encoder.flush(),
+            Compressor::Zstd(encoder) => encoder.flush(),
         }
     }
 }
-
+// 19 is used here as its 19 for fedora
 impl std::str::FromStr for Compressor {
     type Err = RPMError;
     fn from_str(raw: &str) -> Result<Self, Self::Err> {
         match raw {
             "none" => Ok(Compressor::None(Vec::new())),
             "gzip" => Ok(Compressor::Gzip(libflate::gzip::Encoder::new(Vec::new())?)),
+            "zstd" => Ok(Compressor::Zstd(zstd::stream::Encoder::new(
+                Vec::new(),
+                19,
+            )?)),
             _ => Err(RPMError::UnknownCompressorType(raw.to_string())),
         }
     }
@@ -38,6 +44,7 @@ impl Compressor {
         match self {
             Compressor::None(data) => Ok(data),
             Compressor::Gzip(encoder) => Ok(encoder.finish().into_result()?),
+            Compressor::Zstd(encoder) => Ok(encoder.finish().unwrap()),
         }
     }
 
@@ -47,6 +54,10 @@ impl Compressor {
             Compressor::Gzip(_) => Some(CompressionDetails {
                 compression_level: "9",
                 compression_name: "gzip",
+            }),
+            Compressor::Zstd(_) => Some(CompressionDetails {
+                compression_level: "19",
+                compression_name: "zstd",
             }),
         }
     }


### PR DESCRIPTION
fedora has moved to zstd compression at level 19. this pr adds that functionality using the zstd library.  This based off https://github.com/drahnr/rpm-rs as it was the only version that would compile with pgp. I've bumped the pgp version to 0.7.2 as all tests pass without any issues. 