### PR TITLE
feat: Add enum for FileMode

### DIFF
--- a/src/compat_tests.rs
+++ b/src/compat_tests.rs
@@ -124,7 +124,7 @@ mod pgp {
             .with_file(
                 cargo_file.to_str().unwrap(),
                 RPMFileOptions::new("/etc/foobar/hugo/bazz.toml")
-                    .mode(0o100_777)
+                    .mode(FileMode::regular(0o777))
                     .is_config(),
             )?
             .with_file(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -481,18 +481,17 @@ pub const RPMFILE_DOC: i32 = 1 << 1;
 // const RPMFILE_README: i32 = (1 << 8);
 // const RPMFILE_EXCLUDE: i32 = (1 << 9);
 
-
 // copied from rpmpgp.h
-// should be technically equiv to 
+// should be technically equiv to
 // `pgp::crypto::hash::HashAlgorithm`
 // but that is only available with feature `signature`
-pub const PGPHASHALGO_MD5: i32 =  1;
-pub const PGPHASHALGO_SHA1: i32 =  2;
-pub const PGPHASHALGO_RIPEMD160: i32 =  3;
-pub const PGPHASHALGO_MD2: i32 =  5;
-pub const PGPHASHALGO_TIGER192: i32 =  6;
-pub const PGPHASHALGO_HAVAL_5_160: i32 =  7;
-pub const PGPHASHALGO_SHA256: i32 =  8;
-pub const PGPHASHALGO_SHA384: i32 =  9;
+pub const PGPHASHALGO_MD5: i32 = 1;
+pub const PGPHASHALGO_SHA1: i32 = 2;
+pub const PGPHASHALGO_RIPEMD160: i32 = 3;
+pub const PGPHASHALGO_MD2: i32 = 5;
+pub const PGPHASHALGO_TIGER192: i32 = 6;
+pub const PGPHASHALGO_HAVAL_5_160: i32 = 7;
+pub const PGPHASHALGO_SHA256: i32 = 8;
+pub const PGPHASHALGO_SHA384: i32 = 9;
 pub const PGPHASHALGO_SHA512: i32 = 10;
 pub const PGPHASHALGO_SHA224: i32 = 11;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,7 +99,7 @@ pub enum RPMError {
     UnsupportedFileDigestAlgorithm(FileDigestAlgorithm),
 
     #[error("invalid file mode {raw_mode} - {reason}")]
-    InvalidFileMode{ raw_mode: i32, reason: &'static str},
+    InvalidFileMode { raw_mode: i32, reason: &'static str },
 }
 
 impl From<nom::Err<(&[u8], nom::error::ErrorKind)>> for RPMError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,6 +97,9 @@ pub enum RPMError {
 
     #[error("unsupported file digest algorithm {0:?}")]
     UnsupportedFileDigestAlgorithm(FileDigestAlgorithm),
+
+    #[error("invalid file mode {raw_mode} - {reason}")]
+    InvalidFileMode{ raw_mode: i32, reason: &'static str},
 }
 
 impl From<nom::Err<(&[u8], nom::error::ErrorKind)>> for RPMError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!                 "./test_assets/awesome.toml",
 //!                 // you can set a custom mode and custom user too
 //!                 rpm::RPMFileOptions::new("/etc/awesome/second.toml")
-//! 						.mode(0o100744)
+//! 						.mode(rpm::FileMode::regular(0o644))
 //! 						.user("hugo"),
 //!             )?
 //!             .pre_install_script("echo preinst")

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -127,7 +127,7 @@ impl RPMBuilder {
         input.read_to_end(&mut content)?;
         let mut options = options.into();
         if options.inherit_permissions {
-            options.mode = file_mode(&input)? as i32;
+            options.mode = (file_mode(&input)? as i32).into();
         }
         self.add_data(
             content,
@@ -187,7 +187,7 @@ impl RPMBuilder {
             flag: options.flag,
             user: options.user,
             group: options.group,
-            mode: options.mode as i16,
+            mode: options.mode,
             link: options.symlink,
             modified_at,
             dir: dir.clone(),
@@ -372,7 +372,7 @@ impl RPMBuilder {
         for (cpio_path, entry) in self.files.iter() {
             combined_file_sizes += entry.size;
             file_sizes.push(entry.size);
-            file_modes.push(entry.mode);
+            file_modes.push(entry.mode.into());
             // I really do not know the difference. It seems like file_rdevice is always 0 and file_device number always 1.
             // Who knows, who cares.
             file_rdevs.push(0);
@@ -395,7 +395,7 @@ impl RPMBuilder {
             file_verify_flags.push(-1);
             let content = entry.content.to_owned().unwrap();
             let mut writer = cpio::newc::Builder::new(&cpio_path)
-                .mode(entry.mode as u32)
+                .mode(entry.mode.into())
                 .ino(ino_index as u32)
                 .uid(self.uid.unwrap_or(0))
                 .gid(self.gid.unwrap_or(0))

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -1,11 +1,10 @@
 //! A collection of types used in various header records.
-
-use crate::constants::*;
+use crate::{constants::*, errors};
 
 /// Describes a file present in the rpm file.
 pub struct RPMFileEntry {
     pub(crate) size: i32,
-    pub(crate) mode: i16,
+    pub(crate) mode: FileMode,
     pub(crate) modified_at: i32,
     pub(crate) sha_checksum: String,
     pub(crate) link: String,
@@ -17,6 +16,163 @@ pub struct RPMFileEntry {
     pub(crate) content: Option<Vec<u8>>,
 }
 
+#[non_exhaustive]
+#[derive(Copy, Clone, PartialEq, Eq, Debug,Hash)]
+pub enum FileMode {
+    // It does not really matter if we use u16 or i16 since all we care about
+    // is the bit representation which is the same for both.
+    Dir { permissions: u16 },
+    Regular { permissions: u16 },
+    // For "Invalid" we use a larger integer since it is possible to create an invalid
+    // FileMode by providing an overflowing integer.
+    Invalid { raw_mode: i32, reason: &'static str },
+}
+
+// there are more file types but in the context of RPM, only regular and directory should be relevant.
+// See https://man7.org/linux/man-pages/man7/inode.7.html section "The file type and mode"
+const FILE_TYPE_BIT_MASK: u16 = 0o170000; // bit representation = "1111000000000000"
+const PERMISSIONS_BIT_MASK: u16 = 0o7777; // bit representation = "0000111111111111"
+const REGULAR_FILE_TYPE: u16 = 0o100000; //  bit representation = "1000000000000000"
+const DIR_FILE_TYPE: u16 = 0o040000; //      bit representation = "0100000000000000"
+
+impl From<u16> for FileMode {
+    fn from(raw_mode: u16) -> Self {
+        // example
+        //  1111000000000000  (0o170000)  <- file type bit mask
+        // &1000000111101101  (0o100755)  <- regular executable file
+        // -----------------------------
+        //  1000000000000000  (0o100000)  <- type for regular files
+        //
+        // we effectively extract the file type bits with an AND operation.
+        // Here are two links for a quick refresh:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND
+        // https://en.wikipedia.org/wiki/Bitwise_operation#AND
+        let file_type = raw_mode & FILE_TYPE_BIT_MASK;
+        let permissions = raw_mode & PERMISSIONS_BIT_MASK;
+        match file_type {
+            DIR_FILE_TYPE => FileMode::Dir { permissions },
+            REGULAR_FILE_TYPE => FileMode::Regular { permissions },
+            _ => FileMode::Invalid {
+                raw_mode: raw_mode as i32,
+                reason: "unknown file type",
+            },
+        }
+    }
+}
+
+impl From<i16> for FileMode {
+    fn from(raw: i16) -> Self {
+        Self::from(raw as u16)
+    }
+}
+
+impl From<i32> for FileMode {
+    fn from(raw_mode: i32) -> Self {
+        // since we ultimatively only deal with 16bit integers
+        // we need to check if a safe convertion to 16bit is doable.
+        if raw_mode > u16::MAX.into() || raw_mode < i16::MIN.into() {
+            FileMode::Invalid {
+                raw_mode,
+                reason: "provided integer is out of 16bit bounds",
+            }
+        } else {
+            FileMode::from(raw_mode as u16)
+        }
+    }
+}
+
+impl FileMode {
+    /// Create a new Regular instance. `permissions` can be between 0 and 0o7777. Values greater will be set to 0o7777.
+    pub fn regular(permissions: u16) -> Self {
+        FileMode::Regular {
+            permissions: permissions & PERMISSIONS_BIT_MASK,
+        }
+    }
+
+    /// Create a new Dir instance. `permissions` can be between 0 and 0o7777. Values greater will be set to 0o7777.
+    pub fn dir(permissions: u16) -> Self {
+        FileMode::Dir {
+            permissions: permissions & PERMISSIONS_BIT_MASK,
+        }
+    }
+
+    /// Usually this should be done with TryFrom, but since we already have a `From` implementation,
+    /// we run into this issue: https://github.com/rust-lang/rust/issues/50133
+    pub fn try_from_raw(raw: i32) -> Result<Self, errors::RPMError> {
+        let mode: FileMode = raw.into();
+        mode.to_result()
+    }
+
+    /// Turns this FileMode into a result. If the mode is Invalid, it will be converted into
+    /// RPMError::InvalidFileMode. Otherwise it is Ok(self).
+    pub fn to_result(self) -> Result<Self, errors::RPMError> {
+        match self {
+            Self::Invalid { raw_mode, reason } => {
+                Err(errors::RPMError::InvalidFileMode { raw_mode, reason })
+            }
+            _ => Ok(self),
+        }
+    }
+
+    /// Returns the complete file mode (type and permissions)
+    pub fn raw_mode(&self) -> u16 {
+        match self {
+            Self::Dir { permissions } | Self::Regular { permissions } => {
+                *permissions | self.file_type()
+            }
+            Self::Invalid {
+                raw_mode,
+                reason: _,
+            } => *raw_mode as u16,
+        }
+    }
+
+    pub fn file_type(&self) -> u16 {
+        match self {
+            Self::Dir { permissions: _ } => DIR_FILE_TYPE,
+            Self::Regular { permissions: _ } => REGULAR_FILE_TYPE,
+            Self::Invalid {
+                raw_mode,
+                reason: _,
+            } => *raw_mode as u16 & FILE_TYPE_BIT_MASK,
+        }
+    }
+
+    pub fn permissions(&self) -> u16 {
+        match self {
+            Self::Dir { permissions } | Self::Regular { permissions } => *permissions,
+            Self::Invalid {
+                raw_mode,
+                reason: _,
+            } => *raw_mode as u16 & PERMISSIONS_BIT_MASK,
+        }
+    }
+}
+
+impl Into<u32> for FileMode {
+    fn into(self) -> u32 {
+        self.raw_mode() as u32
+    }
+}
+
+impl Into<i32> for FileMode {
+    fn into(self) -> i32 {
+        self.raw_mode() as i32
+    }
+}
+
+impl Into<i16> for FileMode {
+    fn into(self) -> i16 {
+        self.raw_mode() as i16
+    }
+}
+
+impl Into<u16> for FileMode {
+    fn into(self) -> u16 {
+        self.raw_mode()
+    }
+}
+
 /// Description of file modes.
 ///
 /// A subset
@@ -25,7 +181,7 @@ pub struct RPMFileOptions {
     pub(crate) user: String,
     pub(crate) group: String,
     pub(crate) symlink: String,
-    pub(crate) mode: i32,
+    pub(crate) mode: FileMode,
     pub(crate) flag: i32,
     pub(crate) inherit_permissions: bool,
 }
@@ -38,7 +194,7 @@ impl RPMFileOptions {
                 user: "root".to_string(),
                 group: "root".to_string(),
                 symlink: "".to_string(),
-                mode: 0o100_664,
+                mode: FileMode::regular(0o664),
                 flag: 0,
                 inherit_permissions: true,
             },
@@ -66,8 +222,8 @@ impl RPMFileOptionsBuilder {
         self
     }
 
-    pub fn mode(mut self, mode: i32) -> Self {
-        self.inner.mode = mode;
+    pub fn mode<T: Into<FileMode>>(mut self, mode: T) -> Self {
+        self.inner.mode = mode.into();
         self.inner.inherit_permissions = false;
         self
     }
@@ -158,5 +314,104 @@ impl Dependency {
             sense,
             version,
         }
+    }
+}
+
+mod test {
+
+    #[test]
+    fn test_file_mode() -> Result<(), Box<dyn std::error::Error>> {
+        use super::*;
+
+        // test constructor functions
+        let test_table = vec![(0, 0), (0o7777, 0o7777), (0o17777, 0o7777)];
+        for (permissions, expected) in test_table {
+            let result = FileMode::dir(permissions);
+            assert_eq!(expected, result.permissions());
+            let result = FileMode::regular(permissions);
+            assert_eq!(expected, result.permissions());
+        }
+
+        let test_table = vec![
+            (0o10_0664, Ok(FileMode::regular(0o664))),
+            (0o04_0665, Ok(FileMode::dir(0o665))),
+            // test sticky bit
+            (0o10_1664, Ok(FileMode::regular(0o1664))),
+            (
+                0o664,
+                Err(errors::RPMError::InvalidFileMode {
+                    raw_mode: 0o664,
+                    reason: "unknown file type",
+                }),
+            ),
+            (
+                0o27_1664,
+                Err(errors::RPMError::InvalidFileMode {
+                    raw_mode: 0o27_1664,
+                    reason: "provided integer is out of 16bit bounds",
+                }),
+            ),
+        ];
+
+        // test try_from_raw
+        for (testant, expected) in test_table {
+            let result = FileMode::try_from_raw(testant);
+            match (&expected, &result) {
+                (Ok(expected), Ok(actual)) => {
+                    assert_eq!(expected, actual);
+                }
+                (Err(expected), Err(actual)) => {
+                    if let errors::RPMError::InvalidFileMode {
+                        raw_mode: actual_raw_mode,
+                        reason: actual_reason,
+                    } = actual
+                    {
+                        if let errors::RPMError::InvalidFileMode {
+                            raw_mode: expected_raw_mode,
+                            reason: expected_reason,
+                        } = expected
+                        {
+                            assert_eq!(expected_raw_mode, actual_raw_mode);
+                            assert_eq!(expected_reason, actual_reason);
+                        } else {
+                            unreachable!();
+                        }
+                    } else {
+                        panic!("invalid error type");
+                    }
+                }
+                _ => panic!("a and b not equal,{:?} vs {:?}", expected, result),
+            }
+        }
+
+        // test into methods
+        let test_table = vec![
+            (0o10_0755, FileMode::regular(0o0755), REGULAR_FILE_TYPE),
+            (0o10_1755, FileMode::regular(0o1755), REGULAR_FILE_TYPE),
+            (0o04_0755, FileMode::dir(0o0755), DIR_FILE_TYPE),
+            (
+                0o20_0755,
+                FileMode::Invalid {
+                    raw_mode: 0o20_0755,
+                    reason: "provided integer is out of 16bit bounds",
+                },
+                0,
+            ),
+            (
+                0o0755,
+                FileMode::Invalid {
+                    raw_mode: 0o0755,
+                    reason: "unknown file type",
+                },
+                0,
+            ),
+        ];
+        for (raw_mode, expected_mode, expected_type) in test_table {
+            let mode = FileMode::from(raw_mode);
+            assert_eq!(expected_mode, mode);
+            assert_eq!(raw_mode as u16, mode.raw_mode());
+            assert_eq!(expected_type, mode.file_type());
+        }
+        Ok(())
     }
 }

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -17,7 +17,7 @@ pub struct RPMFileEntry {
 }
 
 #[non_exhaustive]
-#[derive(Copy, Clone, PartialEq, Eq, Debug,Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum FileMode {
     // It does not really matter if we use u16 or i16 since all we care about
     // is the bit representation which is the same for both.


### PR DESCRIPTION
This API help users to correctly set file modes including file types.
Currently only the types `dir` (0o04_0000) and `regular` (0o10_0000)
are supported.
It is still possible to create RPM packages by specifying the raw file mode.
This is mainly for backwards compatibility.

Fixes #31