### PR TITLE
Package updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ chrono = "0.4"
 log = "0.4"
 itertools = "0.10"
 hex = { version = "0.4", features = ["std"] }
-zstd = "0.9.0"
+zstd = "0.11"
 
 [dev-dependencies]
 rsa = { version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cpio = "0.2"
 libflate = "1"
 sha2 = "0.10"
 md-5 = "0.10"
-sha1 = "0.6"
+sha1 = "0.10"
 rand = { version = "0.8" }
 pgp = { version="0.7.2", optional = true }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ zstd = "0.9.0"
 rsa = { version = "0.5" }
 rsa-der = { version = "^0.2.1" }
 env_logger = "0.9"
-serial_test = "0.5"
+serial_test = "0.6"
 tokio = {version = "1", features = ["full"]}
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ enum-display-derive = "0.1"
 cpio = "0.2"
 # consider migrating to flate2
 libflate = "1"
-sha2 = "0.9"
-md-5 = "0.9"
+sha2 = "0.10"
+md-5 = "0.10"
 sha1 = "0.6"
 rand = { version = "0.8" }
 pgp = { version="0.7.2", optional = true }

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -370,9 +370,9 @@ impl RPMBuilder {
         let digest_md5 = digest_md5.as_slice();
 
         // header only, not the lead, just the header index
-        let digest_sha1 = sha1::Sha1::from(&header);
-        let digest_sha1 = digest_sha1.digest();
-        let digest_sha1 = digest_sha1.to_string();
+        let digest_sha1 = sha1::Sha1::new_with_prefix(&header);
+        let digest_sha1 = digest_sha1.finalize();
+        let digest_sha1 = hex::encode(digest_sha1);
 
         Ok((digest_sha1, digest_md5.to_vec()))
     }

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -88,8 +88,8 @@ impl RPMPackage {
 
         let digest_md5 = hash_result.as_slice();
 
-        let digest_sha1 = sha1::Sha1::from(&header_bytes);
-        let digest_sha1 = digest_sha1.digest();
+        let digest_sha1 = sha1::Sha1::new_with_prefix(&header_bytes);
+        let digest_sha1 = digest_sha1.finalize();
 
         let rsa_signature_spanning_header_only = signer.sign(header_bytes.as_slice())?;
 
@@ -101,7 +101,7 @@ impl RPMPackage {
         self.metadata.signature = Header::<IndexSignatureTag>::new_signature_header(
             header_and_content_cursor.len() as i32,
             digest_md5,
-            digest_sha1.to_string(),
+            hex::encode(digest_sha1),
             rsa_signature_spanning_header_only.as_slice(),
             rsa_signature_spanning_header_and_archive.as_slice(),
         );


### PR DESCRIPTION
I ran into "dependency hell" related to rpm-rs using old crate versions when trying to upgrade dependencies in https://github.com/indygreg/PyOxidizer/. It's unfortunate that this happens in the first place. But it is what it is.

I pieced together a few commits to upgrade most of the crates in this project to their latest versions. `cargo upgrades` (from `cargo-upgrades` crate) tells me only the `rsa` and `rsa-der` crates are lagging behind after this change. Unfortunately, it appears we can't touch either due to the latest version of the `pgp` crate depending on the current versions. So this PR takes us as far as we can currently go.

While I'm here, could you please set expectations on ETA for a new release? I'd like to decide if I should wait for a new version of this crate or temporarily disable some projects due to crate incompatibilities. (I wish I didn't have to burden you with this request. But that's the world that crates.io crates for us for better or for worse.)