### PR TITLE
Add Vendor and Url options to rpm metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome p
             .add_changelog_entry("you", "yeah, it was", 12312312)
             .requires(Dependency::any("wget"))
             .build_and_sign(Signer::load_from_asc_bytes(&raw_secret_key)?)
+            .vendor("corporation or individual")
+            .repository("www.github.com/repo")
 let mut f = std::fs::File::create("./awesome.rpm")?;
 pkg.write(&mut f)?;
 

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -76,6 +76,9 @@ pub struct RPMBuilder {
     changelog_entries: Vec<String>,
     changelog_times: Vec<i32>,
     compressor: Compressor,
+
+    vendor: Option<String>,
+    url: Option<String>,
 }
 
 impl RPMBuilder {
@@ -104,9 +107,19 @@ impl RPMBuilder {
             changelog_times: Vec::new(),
             compressor: Compressor::None(Vec::new()),
             directories: BTreeSet::new(),
+            vendor: None,
+            url: None,
         }
     }
 
+    pub fn vendor<T: Into<String>>(mut self, content: T) -> Self {
+        self.vendor = Some(content.into());
+        self
+    }
+    pub fn url<T: Into<String>>(mut self, content: T) -> Self {
+        self.url = Some(content.into());
+        self
+    }
     pub fn epoch(mut self, epoch: i32) -> Self {
         self.epoch = epoch;
         self
@@ -864,6 +877,22 @@ impl RPMBuilder {
                 IndexTag::RPMTAG_POSTUN,
                 offset,
                 IndexData::StringTag(self.post_uninst_script.unwrap()),
+            ));
+        }
+
+        if self.vendor.is_some() {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_VENDOR,
+                offset,
+                IndexData::StringTag(self.vendor.unwrap()),
+            ));
+        }
+
+        if self.url.is_some() {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_URL,
+                offset,
+                IndexData::StringTag(self.url.unwrap()),
             ));
         }
 

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -78,7 +78,7 @@ pub struct RPMBuilder {
     compressor: Compressor,
 
     vendor: Option<String>,
-    url: Option<String>,
+    repository: Option<String>,
 }
 
 impl RPMBuilder {
@@ -108,7 +108,7 @@ impl RPMBuilder {
             compressor: Compressor::None(Vec::new()),
             directories: BTreeSet::new(),
             vendor: None,
-            url: None,
+            repository: None,
         }
     }
 
@@ -116,8 +116,8 @@ impl RPMBuilder {
         self.vendor = Some(content.into());
         self
     }
-    pub fn url<T: Into<String>>(mut self, content: T) -> Self {
-        self.url = Some(content.into());
+    pub fn repository<T: Into<String>>(mut self, content: T) -> Self {
+        self.repository = Some(content.into());
         self
     }
     pub fn epoch(mut self, epoch: i32) -> Self {
@@ -888,11 +888,11 @@ impl RPMBuilder {
             ));
         }
 
-        if self.url.is_some() {
+        if self.repository.is_some() {
             actual_records.push(IndexEntry::new(
                 IndexTag::RPMTAG_URL,
                 offset,
-                IndexData::StringTag(self.url.unwrap()),
+                IndexData::StringTag(self.repository.unwrap()),
             ));
         }
 


### PR DESCRIPTION
I was hoping to add more fields to rpm metadata for use with cargo-generate-rpm. This merge adds vendor and url as options for inclusion in metadata.